### PR TITLE
Add tests related to empty expressions

### DIFF
--- a/expressions.html
+++ b/expressions.html
@@ -53,6 +53,22 @@
 			<td>[40 +]</td>
 			<td mv-expressions="none">[40 +]</td>
 		</tr>
+		<tr title="Empty expression ignored">
+			<td>[]</td>
+			<td mv-expressions="none">[]</td>
+		</tr>
+		<tr title="Space-only expression ignored">
+			<td>[  ]</td>
+			<td mv-expressions="none">[  ]</td>
+		</tr>
+		<tr title="Consecutive expressions">
+			<td>[2 + 2][1 + 1]</td>
+			<td mv-expressions="none">42</td>
+		</tr>
+		<tr title="Expression after empty expression still parsed">
+			<td>[][2 + 2]</td>
+			<td mv-expressions="none">[]4</td>
+		</tr>
 		<tr title="Multiline expression">
 			<td>[
 				40 + 2]</td>

--- a/value.html
+++ b/value.html
@@ -51,6 +51,10 @@
 			<td><input mv-value="39 + 3" value="In attribute"></td>
 			<td><input value="42"></td>
 		</tr>
+		<tr title="Empty expression">
+			<td><div mv-value="">You shouldn't see this</div></td>
+			<td></td>
+		</tr>
 		<tr title="Object">
 			<td>
 				<div property="group1" typeof mv-value="{foo: 1, bar: 2}">


### PR DESCRIPTION
Incidentally includes a test for two consecutive expressions side-by-side because it doesn't look like there was one. Should all pass after https://github.com/mavoweb/mavo/pull/393 is merged.